### PR TITLE
Improve dividing by zero handling

### DIFF
--- a/collate_assessments_changes/sql/collate_assessments_changes.sql
+++ b/collate_assessments_changes/sql/collate_assessments_changes.sql
@@ -42,15 +42,15 @@ assessments_joined AS (
 assessments_changes AS (
   SELECT *,
     value_2026 - value_2025 AS change_2025_2026_absolute,
-    value_2026 / (value_2025 + 1) AS change_2025_2026_change_relative,
+    SAFE_DIVIDE(value_2026, value_2025) AS change_2025_2026_change_relative,
     value_2025 - value_2024 AS change_2024_2025_absolute,
-    value_2025 / (value_2024 + 1) AS change_2024_2025_change_relative,
+    SAFE_DIVIDE(value_2025, value_2024) AS change_2024_2025_change_relative,
     value_2024 - value_2023 AS change_2023_2024_absolute,
-    value_2024 / (value_2023 + 1) AS change_2023_2024_change_relative,
+    SAFE_DIVIDE(value_2024, value_2023) AS change_2023_2024_change_relative,
     value_2023 - value_2022 AS change_2022_2023_absolute,
-    value_2023 / (value_2022 + 1) AS change_2022_2023_change_relative,
+    SAFE_DIVIDE(value_2023, value_2022) AS change_2022_2023_change_relative,
     value_2022 - value_2021 AS change_2021_2022_absolute,
-    value_2022 / (value_2021 + 1) AS change_2021_2022_change_relative
+    SAFE_DIVIDE(value_2022, value_2021) AS change_2021_2022_change_relative
   FROM assessments_joined
 ),
 

--- a/pipelines/DEPLOY.md
+++ b/pipelines/DEPLOY.md
@@ -12,7 +12,7 @@ gcloud workflows deploy main-processing-pipeline \
 gcloud scheduler jobs create http main-processing-pipeline \
 --project=musa5090s25-team2 \
 --location=us-east4 \
---schedule='0 9 * * 1' \
+--schedule='30 9 * * 1' \
 --time-zone='America/New_York' \
 --uri='https://workflowexecutions.googleapis.com/v1/projects/musa5090s25-team2/locations/us-east4/workflows/main-processing-pipeline/executions' \
 --oauth-service-account-email='data-pipeline-robot-claudia@musa5090s25-team2.iam.gserviceaccount.com'


### PR DESCRIPTION
# Description

For the calculation of relative assessments changes, use `safe_divide` instead of adding 1 to the denominator

## Type of change

- [x] Bug fix

## Post-merge follow-ups

The pipeline with the changes will run at 9:30 Monday May 12. This will create rows with NULL values for change, so the downstream effects should be monitored.

- [x] Actions required (specified above)
